### PR TITLE
[New Feature]: Automatically publish to WinGet

### DIFF
--- a/.github/workflows/ecode-release.yml
+++ b/.github/workflows/ecode-release.yml
@@ -489,3 +489,16 @@ jobs:
           prerelease: true
           files: |
             projects/haiku/ecode/ecode-haiku-${{ env.INSTALL_REF }}-x86_64.tar.gz
+
+  publish_winget:
+    name: Publish to WinGet
+    needs: [release, build_windows_cross, build_windows_arm64_cross]
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with: 
+          identifier: SpartanJ.ecode
+          version: ${{ needs.release.outputs.version }}
+          token: ${{ secrets.WINGET_TOKEN }}
+          max-versions-to-keep: 7
+          installers-regex: '\.zip$'


### PR DESCRIPTION
## What's new?

- Integrates the `vedantmgoyal9/winget-releaser` action into the release workflow.
- Ensures Windows users can easily install and update the application via WinGet.
- Uses the generated release version and ZIP installers for publication.

- Resolve #286

> [!WARNING]
> 
> I haven't tested the addition job(s) locally. They should work as expected.
> 
> [`nektos/act`](https://github.com/nektos/act) can be used to run "simulated" GitHub Runners locally, but `publish_winget` job and previous build jobs are running on different OS. `act` might not suite for the local test.

> [!IMPORTANT]
> 
> The job uses `secrets.WINGET_TOKEN` to login GitHub and create pull request in `microsoft/winget-pkgs`. This GitHub Secret should be configured properly before the newer workflow file is triggered. 
> 
> Configure it as instructed [here](https://github.com/marketplace/actions/winget-releaser#getting-started-).